### PR TITLE
Added the date.timezone directive to php.ini.

### DIFF
--- a/php.ini
+++ b/php.ini
@@ -1,2 +1,3 @@
 [php]
+date.timezone = 'CST6CDT'
 log_errors = On


### PR DESCRIPTION
It fixes the 

> Warning: date() [function.date]: It is not safe to rely on the system's timezone settings. You are required to use the date.timezone setting or the date_default_timezone_set() function.

which causes certain automated tests to fail.
